### PR TITLE
Add script to automate downloading of movie info

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ pytz = "*"
 pillow = "*"
 colorthief = "*"
 requests = "*"
+pick = "*"
 
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "cbdefd2899eb708d790a0996b848200e3d9dc699604dba01136af27c637aeeb3"
+            "sha256": "0f747e2db97a3ade8aa818ef6391c3ccd58ab713f1ac4a2ee983ddcd0356f204"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
@@ -62,6 +62,13 @@
                 "sha256:61f2ca0cd0aa77279eb943c07f607438edf374096b66332fae1ee64a6f0f73ad"
             ],
             "version": "==0.44"
+        },
+        "pick": {
+            "hashes": [
+                "sha256:d3b2385eed5b89b6387f6353663631fa53c8a9577a26eaa7dbe2df8bc1cc8fb6",
+                "sha256:176ca8bfb3f0601281e88f85eb28a8d1c0c2ad76f1a554ffbe939eee593ec9aa"
+            ],
+            "version": "==0.6.3"
         },
         "pillow": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -1,38 +1,26 @@
 # sga-weekly-movies
 An archive of the SGA weekly movies
 
-My goal is (as automatically as possible, ofc) to input a movie title/year, the days and times of the showing, and fetch both the info json _and_ to download the poster into the repo, so that we don't abuse the image hosts.
+To add a new movie:
 
-For now, I'm adding these manually – I'll eventually subscribe to <http://www.omdbapi.com> for the automation / because I feel guilty manually scraping them.
+1. Get an OMDB API key: http://www.omdbapi.com/apikey.aspx
+2. Take the key they email you, and export it: `export OMDB_API_KEY="my-key"`
+    - I recommend putting this in your shell's config file (`~/.bashrc`, `~/.config/fish/config.fish`, etc)
+3. Install Pipenv, if you don't have it already: https://docs.pipenv.org
+4. Install our dependencies: `pipenv install && npm install`
+5. Download the movie info: `pipenv run python bin/download-movie.py YYYY-MM-DD MovieName`
+    - `YYYY-MM-DD` is the date that the movie will be shown
+    - `MovieName` is the name of the movie
+    - The script will ask you to pick the correct movie
+6. Make sure the "showings" are correct (in `showings.json`) – sometimes SGA shows movies on odd days/times
+7. Download the posters: `pipenv run python bin/download-posters.py`
+8. Reformat the JSON files: `npm run prettier`
+9. Commit and PR!
 
 ---
 
-If you create a movie folder and add "movie.json" to it, you can just run
-
-```bash
-pipenv run python bin/download-posters.py
-```
-
-which will go download any posters that aren't already downloaded.
-
-If you don't have Pipenv installed, you'll need to install [Pipenv](https://docs.pipenv.org), then `pipenv install` in this repository folder.
-
----
-
-To check that your files are workable, you can run
+If you need to check that your files are workable, you can run
 
 ```bash
 pipenv run python bin/build.py
 ```
-
----
-
-The movie folders are named according to the following pattern:
-
-```
-$YEAR-$MONTH-$DAY $NAME
-```
-
-where MONTH-DAY is the first day that the movie is playing.
-
-All days that the movie plays should be recorded in the "showings.json" file, as well as the times that it plays.

--- a/bin/download-movie.py
+++ b/bin/download-movie.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import json
+import argparse
+
+import requests
+from pick import pick
+
+
+API_KEY = os.getenv('OMDB_API_KEY', None)
+
+if not API_KEY:
+    print(f'This tool requires an OMDB api key. If you do not have one, please visit <http://www.omdbapi.com/apikey.aspx>, then `export OMDB_API_KEY="your-key" pipenv run python {sys.argv[0]}`', file=sys.stderr)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Download movie info.')
+    parser.add_argument('date', metavar='SHOW_DATE',
+                        help='the first date shown at Olaf, in YYYY-MM-DD')
+    parser.add_argument('title', metavar='TITLE',
+                        help='the movie title to fetch')
+    parser.add_argument('--year', default=None, help='the year the movie was released')
+
+    args = parser.parse_args()
+    # args.date = args.date.replace('/', '-')
+
+    return args
+
+
+def get_movie(imdbID):
+    params = {'i': imdbID, 'apiKey': API_KEY, 'plot': 'short'}
+    r = requests.get('http://www.omdbapi.com/', params=params)
+    results = r.json()
+    return results
+
+
+def find_movie(title, year):
+    params = {'s': title, 'apiKey': API_KEY, 'type': 'movie'}
+    if year:
+        params['y'] = year
+    r = requests.get('http://www.omdbapi.com/', params=params)
+    results = r.json()
+    options = [f'{m["Title"]} ({m["Year"]}) <{m["Poster"]}>' for m in results['Search']]
+    [_, chosen_index] = pick(options)
+
+    chosen_movie = results['Search'][chosen_index]
+
+    return get_movie(chosen_movie['imdbID'])
+
+
+def main():
+    args = parse_args()
+
+    movie = find_movie(args.title, args.year)
+
+    movie_dir = os.path.join('movies', f'{args.date} {args.title}')
+    os.makedirs(movie_dir, exist_ok=True)
+    with open(os.path.join(movie_dir, 'movie.json'), 'w', encoding='utf-8') as outfile:
+        json.dump(movie, outfile, ensure_ascii=False, indent=2)
+        outfile.write('\n')
+    with open(os.path.join(movie_dir, 'showings.json'), 'w', encoding='utf-8') as outfile:
+        showings = {
+            'showings': [
+                {
+                    'date': args.date.replace('-', '/'),
+                    'times': ['17:00', '19:30', '22:00'],
+                    'location': 'Viking Theater',
+                },
+            ]
+        }
+        json.dump(showings, outfile, ensure_ascii=False, indent=2)
+        outfile.write('\n')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
@drewvolz 

---

1. Get an OMDB API key: http://www.omdbapi.com/apikey.aspx
2. Take the key they email you, and export it: `export OMDB_API_KEY="my-key"`
    - I recommend putting this in your shell's config file (`~/.bashrc`, `~/.config/fish/config.fish`, etc)
3. Install Pipenv, if you don't have it already: https://docs.pipenv.org
4. Install our dependencies: `pipenv install && npm install`
5. Download the movie info: `pipenv run python bin/download-movie.py YYYY-MM-DD MovieName`
    - `YYYY-MM-DD` is the date that the movie will be shown
    - `MovieName` is the name of the movie
    - The script will ask you to pick the correct movie
6. Make sure the "showings" are correct (in `showings.json`) – sometimes SGA shows movies on odd days/times
7. Download the posters: `pipenv run python bin/download-posters.py`
8. Reformat the JSON files: `npm run prettier`
9. Commit and PR!
